### PR TITLE
Fix conditionally uncollapsible categories

### DIFF
--- a/modules/facetedCategory.js
+++ b/modules/facetedCategory.js
@@ -11,12 +11,13 @@ function main() {
   var directCats = mw.config.get('wgDirectCategories');
 
   var catlinks = document.querySelector('#mw-normal-catlinks');
-  var catlinkItems = document.querySelectorAll('#mw-normal-catlinks li');
+  var catlinkItems = document.querySelectorAll(
+    '#mw-normal-catlinks li, #mw-hidden-catlinks li'
+  );
 
   if (!catlinks || directCats.length == catlinkItems.length) {
     return;
   }
-  console.log(catlinkItems.length);
   for (var i = 0, len = catlinkItems.length; i < len; i++) {
     if (!directCats.includes(catlinkItems[i].innerText)) {
       catlinkItems[i].classList.add('collapsible');


### PR DESCRIPTION
The categories on https://femiwiki.com/index.php?oldid=227395 are not collapsible as

- `mw.config.get('wgDirectCategories')` &rarr; `['스포일러가 포함된 문서', '성격/게임', '주제/전쟁']`
- `document.querySelector('#mw-normal-catlinks')` &rarr; `<ul><li>성격/게임</li><li>주제/전쟁</li><li>성격/콘텐츠</li></ul>`
- Therefore `mw.config.get('wgDirectCategories').length == document.querySelector('#mw-normal-catlinks').length` 

So the hidden categories should be counted.