### PR TITLE
Use ParserOutput::getCategoryNames() instead of ::getCategories()

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -7,7 +7,7 @@
   "license-name": "AGPL-3.0-or-later",
   "type": "specialpage",
   "requires": {
-    "MediaWiki": ">= 1.36.0",
+    "MediaWiki": ">= 1.38.0",
     "extensions": {
       "CategoryTree": "*"
     }

--- a/includes/Hooks/RecursiveCategory.php
+++ b/includes/Hooks/RecursiveCategory.php
@@ -61,7 +61,7 @@ class RecursiveCategory implements
 	 * @inheritDoc
 	 */
 	public function onContentAlterParserOutput( $content, $title, $parserOutput ) {
-		$cats = array_keys( $parserOutput->getCategories() );
+		$cats = $parserOutput->getCategoryNames();
 		if ( !$cats ) {
 			return;
 		}


### PR DESCRIPTION
ParserOutput::getCategories() returns a reference to an internal
array and we'd like to discourage its use.

ParserOutput::getCategoryNames() was added in MW 1.38 so the
minimum required MW version was bumped to match.
