### PR TITLE
Replace deprecated ParserOutput::getCategoies()

### DIFF
--- a/includes/Hooks/RecursiveCategory.php
+++ b/includes/Hooks/RecursiveCategory.php
@@ -61,7 +61,7 @@ class RecursiveCategory implements
 	 * @inheritDoc
 	 */
 	public function onContentAlterParserOutput( $content, $title, $parserOutput ) {
-		$cats = array_keys( $parserOutput->getCategories() );
+		$cats = array_keys( $parserOutput->getCategoryNames() );
 		if ( !$cats ) {
 			return;
 		}


### PR DESCRIPTION
Fixes #445
